### PR TITLE
Replaced ipairs with numeric indexing, replaced pairs with generalized iteration

### DIFF
--- a/src/cycles.lua
+++ b/src/cycles.lua
@@ -60,7 +60,8 @@ local function cycles(input: any, depth: number?, initialCycles: any): Cycles?
 					return tostring(left) < tostring(right)
 				end
 			end)
-			for _, key in ipairs(inputKeys) do
+			for i = 1, #inputKeys do
+				local key = inputKeys[i]
 				local value = input[key]
 				if includes(childCycles.omit, key) then
 					-- Don't visit omitted keys

--- a/src/findIndex.lua
+++ b/src/findIndex.lua
@@ -8,7 +8,8 @@
 export type FindHandler<Value> = (Value, number) -> boolean
 
 local function findIndex<Value>(input: { Value }, handler: FindHandler<Value>): number?
-	for key, child in ipairs(input) do
+	for key = 1, #input do
+		local child = input[key]
 		if handler(child, key) then
 			return key
 		end

--- a/src/format.lua
+++ b/src/format.lua
@@ -40,7 +40,7 @@ local function format(formatString: string, ...)
 	local texts, subs = splitOn(formatString, "{[^{}]*}")
 	local result = {}
 	-- Iterate through possible curly-brace matches, ignoring escaped and substituting valid ones
-	for i, text in pairs(texts) do
+	for i, text in texts do
 		local unescaped = text:gsub("{{", "{"):gsub("}}", "}")
 		insert(result, unescaped)
 		local placeholder = subs[i] and subs[i]:sub(2, -2)

--- a/src/groupBy.lua
+++ b/src/groupBy.lua
@@ -18,7 +18,7 @@ local function groupBy<Key, Value, GroupKey>(
 	getKey: GroupByHandler<Key, Value, GroupKey> | GroupKey
 ): { [GroupKey]: { Value } }
 	local result = {}
-	for key, child in pairs(input) do
+	for key, child in input do
 		local groupKey
 		if typeof(getKey) == "function" then
 			groupKey = getKey(child, key)

--- a/src/init.lua
+++ b/src/init.lua
@@ -11,7 +11,7 @@ export type Class<Object> = Types.Class<Object>
 export type AnyFunction = Types.AnyFunction
 
 -- Require and add the Dash functions to the Dash table
-for _, fn in pairs(script:GetChildren()) do
+for _, fn in script:GetChildren() do
 	if fn.ClassName == "ModuleScript" then
 		Dash[fn.Name] = require(fn)
 	end

--- a/src/iterator.lua
+++ b/src/iterator.lua
@@ -7,6 +7,8 @@
 	This function can be used to build behaviour that iterates over both arrays and Maps.
 
 	@see Dash.iterable if you want to iterate over a Table with numeric but un-ordered keys.
+	@deprecated use generalized iteration instead.
+
 ]]
 
 local Dash = script.Parent

--- a/src/mapFirst.lua
+++ b/src/mapFirst.lua
@@ -8,7 +8,8 @@
 export type MapHandler<Value, NewValue> = (Value, number) -> NewValue?
 
 local function mapFirst<Value, NewValue>(input: { Value }, handler: MapHandler<Value, NewValue>): NewValue?
-	for index, child in ipairs(input) do
+	for index = 1, #input do
+		local child = input[index]
 		local output = handler(child, index)
 		if output ~= nil then
 			return output

--- a/src/mapOne.lua
+++ b/src/mapOne.lua
@@ -10,7 +10,7 @@
 export type MapHandler<Key, Value, NewValue> = (Value, Key) -> NewValue?
 
 local function mapOne<Key, Value, NewValue>(input: { [Key]: Value }, handler: MapHandler<Key, Value, NewValue>?): NewValue?
-	for key, child in pairs(input) do
+	for key, child in input do
 		local output
 		if handler then
 			output = handler(child, key)

--- a/src/pretty.lua
+++ b/src/pretty.lua
@@ -106,7 +106,8 @@ local function prettyLines(object: any, options: any): { string }
 		-- Compact numeric keys into a simpler array style
 		local maxConsecutiveIndex = 0
 		local first = true
-		for index, value in ipairs(object) do
+		for index = 1, #object do
+			local value = object[index]
 			if valueOptions.omit and includes(valueOptions.omit, index) then
 				-- Don't include keys which are omitted
 				continue
@@ -136,7 +137,7 @@ local function prettyLines(object: any, options: any): { string }
 				return tostring(left) < tostring(right)
 			end
 		end)
-		for _, key in ipairs(objectKeys) do
+		for _, key in objectKeys do
 			local value = object[key]
 			-- We printed a key if it's an index e.g. an integer in the range 1..n.
 			if typeof(key) == "number" and key % 1 == 0 and key >= 1 and key <= maxConsecutiveIndex then

--- a/src/shallowEqual.lua
+++ b/src/shallowEqual.lua
@@ -12,12 +12,12 @@ local function shallowEqual(left: any, right: any)
 	if left == nil or right == nil then
 		return false
 	end
-	for key, value in pairs(left) do
+	for key, value in left do
 		if right[key] ~= value then
 			return false
 		end
 	end
-	for key, value in pairs(right) do
+	for key, value in right do
 		if left[key] ~= value then
 			return false
 		end


### PR DESCRIPTION
### Iteration refactoring:

* Replaced `ipairs` with direct indexed iteration in `src/cycles.lua`, `src/findIndex.lua`, `src/mapFirst.lua`, and `src/pretty.lua`. [[1]](diffhunk://#diff-aebb9d03a97a9b635afa57d6f310ca821c66384c24813e2456a03ad7feae46e9L63-R64) [[2]](diffhunk://#diff-6bd63bd77a9d5f559d96090da1396fe4464a99769e156af16510eb27faaf76b4L11-R12) [[3]](diffhunk://#diff-8c32320afbcab78ef910c4ebf851f6b70de476984d28dafd52b7052c27875a03L11-R12) [[4]](diffhunk://#diff-a98c13bd27243622b6427028f9b6e1d0a56e30d162935e7551c637223cb074f9L109-R110)
* Replaced `pairs` with direct iteration in `src/groupBy.lua`, `src/mapOne.lua`, and `src/shallowEqual.lua`. [[1]](diffhunk://#diff-a5026a464d685be895fe841dea328928669c72c409bded1afcb71f949744bf44L21-R21) [[2]](diffhunk://#diff-ec42a8055ec53f5fbc0180ebe9c8c0e8b7cc2b29c58dfeadb1b2f30043e10748L13-R13) [[3]](diffhunk://#diff-b6076942eb6e02f27049fbd30cea849082b9df83667fd9abc218d6bdf521e4c8L15-R20)
* Updated iteration over `script:GetChildren()` in `src/init.lua` to remove the use of `pairs`.

### Code annotations:

* Added a deprecation notice to the `src/iterator.lua` file, recommending the use of generalized iteration instead of the current method.